### PR TITLE
Add META.json for pgxn.org and script to bundle archives

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,40 @@
+{
+    "name": "musicbrainz_unaccent",
+    "abstract": "Removes accents from Unicode data",
+    "description": "Function and text search dictionary to unaccent Unicode strings. Safe for use in indexes.",
+    "version": "1.0.0",
+    "release_status": "stable",
+
+    "maintainer": "Oliver Charles <ollie@ocharles.org.uk>",
+    "generated_by": "Marti Raudsepp <marti@juffo.org>",
+    "provides": {
+        "musicbrainz_unaccent": {
+            "abstract": "Removes accents from Unicode data",
+            "file": "sql/musicbrainz_unaccent.sql",
+            "docfile": "README.musicbrainz_unaccent.md",
+            "version": "1.0.0"
+        }
+    },
+    "license": {
+        "gpl_2": "http://www.gnu.org/licenses/gpl-2.0.html"
+    },
+    "tags": [
+        "musicbrainz", "unicode", "accents", "unaccent", "languages",
+        "canonicalize"
+    ],
+    "resources": {
+        "bugtracker": {
+            "web": "http://tickets.musicbrainz.org/browse/MBS"
+        },
+        "repository": {
+            "url": "git://github.com/metabrainz/postgresql-musicbrainz-unaccent.git",
+            "web": "https://github.com/metabrainz/postgresql-musicbrainz-unaccent",
+            "type": "git"
+        }
+    },
+
+    "meta-spec": {
+        "version": "1.0.0",
+        "url": "http://pgxn.org/meta/spec.txt"
+    }
+}

--- a/archive.sh
+++ b/archive.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This script generates archive files for uploading to manager.pgxn.org.
+#
+# Usage:
+# ./archive.sh          - generates archives for current git HEAD
+# ./archive.sh 1.0.0    - generates archives for git tag 'v1.0.0'
+#
+# To package up a new version, you have to create an annotated git tag first:
+#
+#   git tag -a v1.0.0 -m 'Tag v1.0.0'
+
+set -e
+
+if [[ -z "$1" ]]; then
+  TAG="$(git describe)"
+  VER="${TAG#v}"
+else
+  VER="$1"
+  TAG="v$VER"
+fi
+
+NAME="musicbrainz_unaccent-$VER"
+echo "Creating `realpath ../$NAME.tar.gz`"
+git archive "$TAG" --prefix "$NAME/" -o "../$NAME.tar.gz"
+echo "Creating `realpath ../$NAME.zip`"
+git archive "$TAG" --prefix "$NAME/" -o "../$NAME.zip"


### PR DESCRIPTION
Please scrutinize META.json thoroughly.

If all looks good, I think this is now ready for PGXN. You can tag 1.0.0 with:

```
git tag -a v1.0.0 -m 'Tag v1.0.0'
```

I will then use archive.sh to generate a PGXN distribution and upload it.
